### PR TITLE
Fixed some settings inconsistency and an issue where the redirect uri was incorrect

### DIFF
--- a/User Owns Data/integrate-dashboard-web-app/PBIWebApp/Cloud.config
+++ b/User Owns Data/integrate-dashboard-web-app/PBIWebApp/Cloud.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <PBIWebApp.Properties.Settings>
   <setting name="ClientID" serializeAs="String">
     <value>{Enter your app ClientID}</value>
-	</setting>
-	<setting name="ClientSecret" serializeAs="String">
-		<value>{Enter your app SecretKey}</value>
+  </setting>
+  <setting name="ClientSecret" serializeAs="String">
+    <value>{Enter your app SecretKey}</value>
   </setting>
   <setting name="AADAuthoritySignInUri" serializeAs="String">
     <value>https://login.windows.net/common/oauth2/authorize/</value>

--- a/User Owns Data/integrate-dashboard-web-app/PBIWebApp/Default.aspx.cs
+++ b/User Owns Data/integrate-dashboard-web-app/PBIWebApp/Default.aspx.cs
@@ -60,7 +60,7 @@ namespace PBIWebApp
                 {"resource", Properties.Settings.Default.PowerBiAPI},
 
                 //After user authenticates, Azure AD will redirect back to the web app
-                {"redirect_uri", "http://localhost:13526/Redirect"}
+                {"redirect_uri", "http://localhost:13526/redirect"}
             };
 
             //Create sign-in query string
@@ -69,7 +69,7 @@ namespace PBIWebApp
 
             //Redirect authority
             //Authority Uri is an Azure resource that takes a client id to get an Access token
-            string authorityUri = Properties.Settings.Default.AADAuthorityUri;
+            string authorityUri = Properties.Settings.Default.AADAuthoritySignInUri;
             var authUri = String.Format("{0}?{1}", authorityUri, queryString);
             Response.Redirect(authUri);
         }
@@ -91,7 +91,7 @@ namespace PBIWebApp
                 {"redirect_uri", "http://localhost:13526/"},
 
                 //After user authenticates, Azure AD will redirect back to the web app
-                {"post_logout_redirect_uri", "http://localhost:13526/Redirect"}
+                {"post_logout_redirect_uri", "http://localhost:13526/redirect"}
             };
 
             //Create sign-in query string
@@ -100,7 +100,7 @@ namespace PBIWebApp
 
             //Redirect authority
             //Authority Uri is an Azure resource that takes a client id to get an Access token
-            string authorityUri = Properties.Settings.Default.AADAuthorityUri;
+            string authorityUri = Properties.Settings.Default.AADAuthoritySignOffUri;
             var authUri = String.Format("{0}?{1}", authorityUri, queryString);
             Response.Redirect(authUri);
         }

--- a/User Owns Data/integrate-dashboard-web-app/PBIWebApp/Properties/Settings.Designer.cs
+++ b/User Owns Data/integrate-dashboard-web-app/PBIWebApp/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace PBIWebApp.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -44,9 +44,18 @@ namespace PBIWebApp.Properties {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("https://login.windows.net/common/oauth2/authorize/")]
-        public string AADAuthorityUri {
+        public string AADAuthoritySignInUri {
             get {
-                return ((string)(this["AADAuthorityUri"]));
+                return ((string)(this["AADAuthoritySignInUri"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://login.windows.net/common/oauth2/logout/")]
+        public string AADAuthoritySignOffUri {
+            get {
+                return ((string)(this["AADAuthoritySignOffUri"]));
             }
         }
         

--- a/User Owns Data/integrate-dashboard-web-app/PBIWebApp/Properties/Settings.settings
+++ b/User Owns Data/integrate-dashboard-web-app/PBIWebApp/Properties/Settings.settings
@@ -11,10 +11,10 @@
     <Setting Name="AADAuthoritySignInUri" Type="System.String" Scope="Application">
       <Value Profile="(Default)">https://login.windows.net/common/oauth2/authorize/</Value>
     </Setting>
+    <Setting Name="AADAuthoritySignOffUri" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://login.windows.net/common/oauth2/logout/</Value>
+    </Setting>
     <Setting Name="PowerBiAPI" Type="System.String" Scope="Application">
-      <Setting Name="AADAuthoritySignOffUri" Type="System.String" Scope="Application">
-        <Value Profile="(Default)">https://login.windows.net/common/oauth2/logout/</Value>
-      </Setting>
       <Value Profile="(Default)">https://analysis.windows.net/powerbi/api</Value>
     </Setting>
     <Setting Name="PowerBiDataset" Type="System.String" Scope="Application">

--- a/User Owns Data/integrate-dashboard-web-app/PBIWebApp/redirect.aspx.cs
+++ b/User Owns Data/integrate-dashboard-web-app/PBIWebApp/redirect.aspx.cs
@@ -18,8 +18,8 @@ namespace PBIWebApp
         protected void Page_Load(object sender, EventArgs e)
         {
             //Redirect uri must match the redirect_uri used when requesting Authorization code.
-            string redirectUri = String.Format("{0}Redirect", Properties.Settings.Default.RedirectUrl);
-            string authorityUri = Properties.Settings.Default.AADAuthorityUri;
+            string redirectUri = String.Format("{0}redirect", Properties.Settings.Default.RedirectUrl);
+            string authorityUri = Properties.Settings.Default.AADAuthoritySignInUri;
 
             // Get the auth code
             string code = Request.Params["code"];


### PR DESCRIPTION
The PBIWebApp (Dashboards Sample) solution currently does not build out of the box due to some settings inconsistency.

There was a previous [commit](https://github.com/Microsoft/PowerBI-Developer-Samples/commit/140a72042ca71f0eee7b8f2568dd8ecb2de65615) that added a sign off button. The commit updated the Settings.settings file by adding a new setting. However the Settings.Designer.cs wasn't updated to reflect the changes, which probably happened since the Settings.settings was modified manually instead of through the UI in Visual Studio. This resulted in this later [commit](https://github.com/Microsoft/PowerBI-Developer-Samples/commit/2ca951137f00d77c3a11ab5a677d5596c358413a) reverting some of the changes.

I fixed these settings issues and an issue where the redirect uri needed to be in lowercase for the authentication to work correctly.