### PR TITLE
Updated error messages - added '' around IDs, to make it clear when t…

### DIFF
--- a/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx
+++ b/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx
@@ -72,7 +72,7 @@
             <br />
             First make sure you <a href="https://dev.powerbi.com/apps">register your app</a>. After registration, copy <u>Client ID</u> and <u>Client Secret</u> to web.config file.
             <br />
-            The application will embed the first report from your Power BI account. If you wish to embed a specific report, please copy the report's Report ID and corresponding Group ID to web.config file.
+            The application will embed the first report from your Power BI account. If you wish to embed a specific report, please copy the report's ID and the corresponding Group ID to web.config file.
         </h2>
     </header>
 

--- a/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx
+++ b/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx
@@ -72,7 +72,7 @@
             <br />
             First make sure you <a href="https://dev.powerbi.com/apps">register your app</a>. After registration, copy <u>Client ID</u> and <u>Client Secret</u> to web.config file.
             <br />
-            The application will embed the first report from your Power BI account. If you wish to embed a specific report, please copy the report's ID and the corresponding Group ID to web.config file.
+            The application will embed the first report from your Power BI account. If you wish to embed a specific report, please copy the report's ID and the corresponding group ID to web.config file.
         </h2>
     </header>
 

--- a/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx.cs
+++ b/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx.cs
@@ -95,7 +95,7 @@ namespace PBIWebApp
                 else
                 {
                     report = client.Reports.GetReports().Value.FirstOrDefault(r => r.Id == reportId);
-                    AppendErrorIfReportNull(report, string.Format("Report with ID: {0} not found. Please check the report ID. For reports within a group with a group ID, add the group ID to the application's settings", reportId));
+                    AppendErrorIfReportNull(report, string.Format("Report with ID: '{0}' not found. Please check the report ID. For reports within a group with a group ID, add the group ID to the application's settings", reportId));
                 }
 
                 if (report != null)
@@ -176,7 +176,7 @@ namespace PBIWebApp
             // No group with the group ID was found.
             if (sourceGroup == null)
             {
-                errorLabel.Text = string.Format("Group with id: {0} not found. Please validate the provided group ID.", groupId);
+                errorLabel.Text = string.Format("Group with id: '{0}' not found. Please validate the provided group ID.", groupId);
                 return null;
             }
 
@@ -198,7 +198,7 @@ namespace PBIWebApp
 
                 catch(HttpOperationException)
                 {
-                    errorLabel.Text = string.Format("Report with ID:{0} not found in the group {1}, Please check the report ID.", reportId, groupId);
+                    errorLabel.Text = string.Format("Report with ID: '{0}' not found in the group with ID: '{1}', Please check the report ID.", reportId, groupId);
 
                 }
             }


### PR DESCRIPTION
Updated error messages - added '' around Ids, to make it clear when the parameter is empty. 
e.g "Group with ID: '' was not found...." instead of "Group with ID: was not found"