### PR TITLE
Fix MinutesToExpiration issue

### DIFF
--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Models/EmbedConfig.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Models/EmbedConfig.cs
@@ -16,7 +16,7 @@ namespace PowerBIEmbedded_AppOwnsData.Models
             get
             {
                 var minutesToExpiration = EmbedToken.Expiration.Value - DateTime.UtcNow;
-                return minutesToExpiration.Minutes;
+                return (int) minutesToExpiration.TotalMinutes;
             }
         }
 


### PR DESCRIPTION
The Minutes from TimeSpan returns the Minutes component of the span.  The attribute TotalMinutes contains the total TimeSpan representation in Minutes.