### PR TITLE
Sample using AppOnly Authentication

### DIFF
--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
@@ -226,10 +226,8 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
 
                     if (dashboard == null)
                     {
-                        return View(new TileEmbedConfig()
-                        {
-                            ErrorMessage = "Workspace has no dashboards."
-                        });
+                        result.ErrorMessage = "Workspace has no dashboards.";
+                        return View(result);
                     }
 
                     var tiles = await client.Dashboards.GetTilesInGroupAsync(WorkspaceId, dashboard.Id);
@@ -243,14 +241,12 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
 
                     if (tokenResponse == null)
                     {
-                        return View(new TileEmbedConfig()
-                        {
-                            ErrorMessage = "Failed to generate embed token."
-                        });
+                        result.ErrorMessage = "Failed to generate embed token.";
+                        return View(result);
                     }
 
                     // Generate Embed Configuration.
-                    var embedConfig = new TileEmbedConfig()
+                    result = new TileEmbedConfig()
                     {
                         EmbedToken = tokenResponse,
                         EmbedUrl = tile.EmbedUrl,
@@ -258,7 +254,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
                         dashboardId = dashboard.Id
                     };
 
-                    return View(embedConfig);
+                    return View(result);
                 }
             }
             catch (HttpOperationException exc)

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
@@ -304,7 +304,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
                 return "WorkspaceId must be a Guid object. Please select a workspace you own and fill its Id in web.config";
             }
 
-            if (AuthenticationType.Equals("AppOwnsData"))
+            if (AuthenticationType.Equals("MasterUser"))
             {
                 // Username must have a value.
                 if (string.IsNullOrWhiteSpace(Username))
@@ -334,7 +334,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
             result = new EmbedConfig { Username = username, Roles = roles, ErrorMessage = string.Empty };
             var authenticationContext = new AuthenticationContext(AuthorityUrl);
             AuthenticationResult authenticationResult = null;
-            if (AuthenticationType.Equals("AppOwnsData"))
+            if (AuthenticationType.Equals("MasterUser"))
             {
                 // Authentication using master user credentials
                 var credential = new UserPasswordCredential(Username, Password);

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -16,26 +16,8 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="AuthenticationType" value="AppOnly" />
+    <add key="AuthenticationType" value="MasterUser" />
   </appSettings>
-
-  <ServicePrinciple>
-    <add key="applicationId" value="" />
-    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
-    <add key="applicationSecret" value="" />
-
-    <add key="workspaceId" value=""/>
-    <!-- The id of the report to embed. If empty, will use the first report in group -->
-    <add key="reportId" value=""/>
-    <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
-    <add key="pbiUsername" value=""/>
-    <add key="pbiPassword" value=""/>
-
-    <add key="authorityUrl" value="https://login.microsoftonline.com/faae7f19-77f3-4fcc-bdaa-487b920cb7ee/oauth2/authorize" />
-    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
-    <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
-    <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
-  </ServicePrinciple>
 
   <MasterUser>
     <add key="applicationId" value="" />
@@ -54,6 +36,25 @@
     <add key="apiUrl" value="https://api.powerbi.com/" />
     <add key="embedUrlBase" value="https://app.powerbi.com/" />
   </MasterUser>
+
+  <ServicePrinciple>
+    <add key="applicationId" value="" />
+    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
+    <add key="applicationSecret" value="" />
+
+    <add key="workspaceId" value=""/>
+    <!-- The id of the report to embed. If empty, will use the first report in group -->
+    <add key="reportId" value=""/>
+    <!-- Note: credentials can be empty in this authentication method. -->
+    <add key="pbiUsername" value=""/>
+    <add key="pbiPassword" value=""/>
+
+    <add key="authorityUrl" value="https://login.microsoftonline.com/faae7f19-77f3-4fcc-bdaa-487b920cb7ee/oauth2/authorize" />
+    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
+    <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
+    <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
+  </ServicePrinciple>
+  
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -7,8 +7,8 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
-    <section name="AppOnly" type="System.Configuration.NameValueSectionHandler" />
-    <section name="AppOwnsData" type="System.Configuration.NameValueSectionHandler" />
+    <section name="ServicePrinciple" type="System.Configuration.NameValueSectionHandler" />
+    <section name="MasterUser" type="System.Configuration.NameValueSectionHandler" />
   </configSections>
 
   <appSettings>
@@ -19,7 +19,7 @@
     <add key="AuthenticationType" value="AppOnly" />
   </appSettings>
 
-  <AppOnly>
+  <ServicePrinciple>
     <add key="applicationId" value="" />
     <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
     <add key="applicationSecret" value="" />
@@ -35,9 +35,9 @@
     <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
     <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
     <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
-  </AppOnly>
+  </ServicePrinciple>
 
-  <AppOwnsData>
+  <MasterUser>
     <add key="applicationId" value="" />
     <!-- Note: applicationSecret can be empty in this authentication method -->
     <add key="applicationSecret" value="" />
@@ -53,7 +53,7 @@
     <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
     <add key="apiUrl" value="https://api.powerbi.com/" />
     <add key="embedUrlBase" value="https://app.powerbi.com/" />
-  </AppOwnsData>
+  </MasterUser>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -7,20 +7,53 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="AppOnly" type="System.Configuration.NameValueSectionHandler" />
+    <section name="AppOwnsData" type="System.Configuration.NameValueSectionHandler" />
   </configSections>
-  <appSettings file="Cloud.config">
-    <add key="webpages:Version" value="3.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
-    <add key="applicationId" value=""/>
+
+  <appSettings>
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="AuthenticationType" value="AppOnly" />
+  </appSettings>
+
+  <AppOnly>
+    <add key="applicationId" value="" />
+    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
+    <add key="applicationSecret" value="" />
+
     <add key="workspaceId" value=""/>
     <!-- The id of the report to embed. If empty, will use the first report in group -->
     <add key="reportId" value=""/>
     <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
     <add key="pbiUsername" value=""/>
     <add key="pbiPassword" value=""/>
-  </appSettings>
+
+    <add key="authorityUrl" value="https://login.microsoftonline.com/faae7f19-77f3-4fcc-bdaa-487b920cb7ee/oauth2/authorize" />
+    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
+    <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
+    <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
+  </AppOnly>
+
+  <AppOwnsData>
+    <add key="applicationId" value="" />
+    <!-- Note: applicationSecret can be empty in this authentication method -->
+    <add key="applicationSecret" value="" />
+
+    <add key="workspaceId" value=""/>
+    <!-- The id of the report to embed. If empty, will use the first report in group -->
+    <add key="reportId" value=""/>
+    <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
+    <add key="pbiUsername" value=""/>
+    <add key="pbiPassword" value=""/>
+
+    <add key="authorityUrl" value="https://login.windows.net/common/oauth2/authorize/" />
+    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
+    <add key="apiUrl" value="https://api.powerbi.com/" />
+    <add key="embedUrlBase" value="https://app.powerbi.com/" />
+  </AppOwnsData>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 


### PR DESCRIPTION
Added support for AppOnly authentication for AppOwnsData samples - embed report, dashboard and tile.
Split config file to 2 sections - one for each authentication method,
and added support in HomeController.
