### PR TITLE
Changes In AppOwnsData Sample - mainly in app structure

### DIFF
--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
@@ -74,5 +74,4 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
             }
         }
     }
-
 }

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
@@ -6,7 +6,6 @@ using PowerBIEmbedded_AppOwnsData.Models;
 using PowerBIEmbedded_AppOwnsData.Services;
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Configuration;
 using System.Linq;
 using System.Reflection;

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
@@ -226,10 +226,8 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
 
                     if (dashboard == null)
                     {
-                        return View(new TileEmbedConfig()
-                        {
-                            ErrorMessage = "Workspace has no dashboards."
-                        });
+                        result.ErrorMessage = "Workspace has no dashboards.";
+                        return View(result);
                     }
 
                     var tiles = await client.Dashboards.GetTilesInGroupAsync(WorkspaceId, dashboard.Id);
@@ -243,14 +241,12 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
 
                     if (tokenResponse == null)
                     {
-                        return View(new TileEmbedConfig()
-                        {
-                            ErrorMessage = "Failed to generate embed token."
-                        });
+                        result.ErrorMessage = "Failed to generate embed token.";
+                        return View(result);
                     }
 
                     // Generate Embed Configuration.
-                    var embedConfig = new TileEmbedConfig()
+                    result = new TileEmbedConfig()
                     {
                         EmbedToken = tokenResponse,
                         EmbedUrl = tile.EmbedUrl,
@@ -258,7 +254,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
                         dashboardId = dashboard.Id
                     };
 
-                    return View(embedConfig);
+                    return View(result);
                 }
             }
             catch (HttpOperationException exc)

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
@@ -198,7 +198,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
 
         public async Task<ActionResult> EmbedTile()
         {
-            var result = new EmbedConfig();
+            EmbedConfig result = new TileEmbedConfig();
             try
             {
                 var error = GetWebConfigErrors();

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
@@ -304,7 +304,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
                 return "WorkspaceId must be a Guid object. Please select a workspace you own and fill its Id in web.config";
             }
 
-            if (AuthenticationType.Equals("AppOwnsData"))
+            if (AuthenticationType.Equals("MasterUser"))
             {
                 // Username must have a value.
                 if (string.IsNullOrWhiteSpace(Username))
@@ -334,7 +334,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
             result = new EmbedConfig { Username = username, Roles = roles, ErrorMessage = string.Empty };
             var authenticationContext = new AuthenticationContext(AuthorityUrl);
             AuthenticationResult authenticationResult = null;
-            if (AuthenticationType.Equals("AppOwnsData"))
+            if (AuthenticationType.Equals("MasterUser"))
             {
                 // Authentication using master user credentials
                 var credential = new UserPasswordCredential(Username, Password);

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Controllers/HomeController.cs
@@ -16,14 +16,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
 {
     public class HomeController : Controller
     {
-        private static readonly string Username = ConfigurationManager.AppSettings["pbiUsername"];
-        private static readonly string Password = ConfigurationManager.AppSettings["pbiPassword"];
-        private static readonly string AuthorityUrl = ConfigurationManager.AppSettings["authorityUrl"];
-        private static readonly string ResourceUrl = ConfigurationManager.AppSettings["resourceUrl"];
-        private static readonly string ApplicationId = ConfigurationManager.AppSettings["ApplicationId"];
-        private static readonly string ApiUrl = ConfigurationManager.AppSettings["apiUrl"];
-        private static readonly string WorkspaceId = ConfigurationManager.AppSettings["workspaceId"];
-        private static readonly string ReportId = ConfigurationManager.AppSettings["reportId"];
+        private readonly IEmbedService m_embedService;
 
         public HomeController()
         {
@@ -35,7 +28,7 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
             return View();
         }
 
-        public async Task<ActionResult> EmbedReport(string username = null, string roles = null)
+        public async Task<ActionResult> EmbedReport(string username, string roles)
         {
             var embedResult = await m_embedService.EmbedReport(username, roles);
             if (embedResult)
@@ -72,59 +65,6 @@ namespace PowerBIEmbedded_AppOwnsData.Controllers
             {
                 return View(m_embedService.TileEmbedConfig);
             }
-        }
-
-        private AuthenticationResult DoAuthentication()
-        {
-            var authenticationContext = new AuthenticationContext(AuthorityUrl);
-            AuthenticationResult authenticationResult = null;
-            if (AuthenticationType.Equals("MasterUser"))
-            {
-                // Authentication using master user credentials
-                var credential = new UserPasswordCredential(Username, Password);
-                authenticationResult = authenticationContext.AcquireTokenAsync(ResourceUrl, ApplicationId, credential).Result;
-            }
-            else
-            {
-                // Authentication using app credentials
-                ClientCredential clientCredential = new ClientCredential(ApplicationId, ApplicationSecret);
-                authenticationResult = authenticationContext.AcquireTokenAsync(ResourceUrl, clientCredential).Result;
-            }
-
-            return authenticationResult;
-        }
-
-        private TokenCredentials GetTokenCredentials(out EmbedConfig result)
-        {
-            result = new EmbedConfig();
-            TokenCredentials tokenCredentials = null;
-
-            var error = GetWebConfigErrors();
-            if (error != null)
-            {
-                result.ErrorMessage = error;
-                return tokenCredentials;
-            }
-
-            AuthenticationResult authenticationResult = null;
-            try
-            {
-                authenticationResult = DoAuthentication();
-            }
-            catch (AggregateException exc)
-            {
-                result.ErrorMessage = exc.InnerException.Message;
-                return tokenCredentials;
-            }
-
-            if (authenticationResult == null)
-            {
-                result.ErrorMessage = "Authentication Failed.";
-                return tokenCredentials;
-            }
-
-            tokenCredentials = new TokenCredentials(authenticationResult.AccessToken, "Bearer");
-            return tokenCredentials;
         }
     }
 

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/PowerBIEmbedded_AppOwnsData.csproj
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/PowerBIEmbedded_AppOwnsData.csproj
@@ -58,6 +58,9 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.9\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.PowerBI.Api, Version=2.1.0.18358, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.PowerBI.Api.2.1.0\lib\netstandard2.0\Microsoft.PowerBI.Api.dll</HintPath>
     </Reference>

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/PowerBIEmbedded_AppOwnsData.csproj
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/PowerBIEmbedded_AppOwnsData.csproj
@@ -144,10 +144,10 @@
     <Reference Include="Microsoft.AspNet.Identity.EntityFramework">
       <HintPath>..\packages\Microsoft.AspNet.Identity.EntityFramework.2.2.1\lib\net45\Microsoft.AspNet.Identity.EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="Owin, Version=1.0.0.0">
+    <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin">
       <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/PowerBIEmbedded_AppOwnsData.csproj
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/PowerBIEmbedded_AppOwnsData.csproj
@@ -58,9 +58,6 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.9\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.PowerBI.Api, Version=2.1.0.18358, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.PowerBI.Api.2.1.0\lib\netstandard2.0\Microsoft.PowerBI.Api.dll</HintPath>
     </Reference>
@@ -71,9 +68,6 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -149,6 +143,12 @@
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.EntityFramework">
       <HintPath>..\packages\Microsoft.AspNet.Identity.EntityFramework.2.2.1\lib\net45\Microsoft.AspNet.Identity.EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
@@ -85,7 +85,7 @@ namespace PowerBIEmbedded_AppOwnsData.Services
                     }
                     else
                     {
-                        report = reports.Value.FirstOrDefault(r => r.Id == ReportId);
+                        report = reports.Value.FirstOrDefault(r => r.Id.Equals(ReportId, StringComparison.InvariantCultureIgnoreCase));
                     }
 
                     if (report == null)

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
@@ -22,12 +22,8 @@ namespace PowerBIEmbedded_AppOwnsData.Services
         private static readonly string ApiUrl = ConfigurationManager.AppSettings["apiUrl"];
         private static readonly string WorkspaceId = ConfigurationManager.AppSettings["workspaceId"];
         private static readonly string ReportId = ConfigurationManager.AppSettings["reportId"];
-
-        private static readonly string AuthenticationType = ConfigurationManager.AppSettings["AuthenticationType"];
-        private static readonly NameValueCollection sectionConfig = ConfigurationManager.GetSection(AuthenticationType) as NameValueCollection;
-        private static readonly string ApplicationSecret = sectionConfig["applicationSecret"];
-        private static readonly string Username = sectionConfig["pbiUsername"];
-        private static readonly string Password = sectionConfig["pbiPassword"];
+        private static readonly string Username = ConfigurationManager.AppSettings["pbiUsername"];
+        private static readonly string Password = ConfigurationManager.AppSettings["pbiPassword"];
 
 
         public EmbedConfig EmbedConfig
@@ -294,26 +290,16 @@ namespace PowerBIEmbedded_AppOwnsData.Services
                 return "Invalid AuthorityUrl. Please fill Tenant ID in AuthorityUrl under web.config";
             }
 
-            if (AuthenticationType.Equals("MasterUser"))
+            // Username must have a value.
+            if (string.IsNullOrWhiteSpace(Username))
             {
-                // Username must have a value.
-                if (string.IsNullOrWhiteSpace(Username))
-                {
-                    return "Username is empty. Please fill Power BI username in web.config";
-                }
-
-                // Password must have a value.
-                if (string.IsNullOrWhiteSpace(Password))
-                {
-                    return "Password is empty. Please fill password of Power BI username in web.config";
-                }
+                return "Username is empty. Please fill Power BI username in web.config";
             }
-            else
+
+            // Password must have a value.
+            if (string.IsNullOrWhiteSpace(Password))
             {
-                if (string.IsNullOrWhiteSpace(ApplicationSecret))
-                {
-                    return "ApplicationSecret is empty. please register your application as Web app and fill appSecret in web.config.";
-                }
+                return "Password is empty. Please fill password of Power BI username in web.config";
             }
 
             return null;
@@ -323,18 +309,10 @@ namespace PowerBIEmbedded_AppOwnsData.Services
         {
             var authenticationContext = new AuthenticationContext(AuthorityUrl);
             AuthenticationResult authenticationResult = null;
-            if (AuthenticationType.Equals("MasterUser"))
-            {
-                // Authentication using master user credentials
-                var credential = new UserPasswordCredential(Username, Password);
-                authenticationResult = authenticationContext.AcquireTokenAsync(ResourceUrl, ApplicationId, credential).Result;
-            }
-            else
-            {
-                // Authentication using app credentials
-                var credential = new ClientCredential(ApplicationId, ApplicationSecret);
-                authenticationResult = await authenticationContext.AcquireTokenAsync(ResourceUrl, credential);
-            }
+
+            // Authentication using master user credentials
+            var credential = new UserPasswordCredential(Username, Password);
+            authenticationResult = await authenticationContext.AcquireTokenAsync(ResourceUrl, ApplicationId, credential);
 
             return authenticationResult;
         }

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
@@ -289,7 +289,7 @@ namespace PowerBIEmbedded_AppOwnsData.Services
             }
 
             // Must fill tenant Id in authorityUrl
-            if (AuthorityUrl.Contains("Fill Tenant ID"))
+            if (AuthorityUrl.Contains("Fill_Tenant_ID"))
             {
                 return "Invalid AuthorityUrl. Please fill Tenant ID in AuthorityUrl under web.config";
             }
@@ -333,7 +333,7 @@ namespace PowerBIEmbedded_AppOwnsData.Services
             {
                 // Authentication using app credentials
                 var credential = new ClientCredential(ApplicationId, ApplicationSecret);
-                authenticationResult = await authenticationContext.AcquireTokenAsync(ResourceUrl, clientCredential);
+                authenticationResult = await authenticationContext.AcquireTokenAsync(ResourceUrl, credential);
             }
 
             return authenticationResult;

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
@@ -288,16 +288,32 @@ namespace PowerBIEmbedded_AppOwnsData.Services
                 return "WorkspaceId must be a Guid object. Please select a workspace you own and fill its Id in web.config";
             }
 
-            // Username must have a value.
-            if (string.IsNullOrWhiteSpace(Username))
+            // Must fill tenant Id in authorityUrl
+            if (AuthorityUrl.Contains("Fill Tenant ID"))
             {
-                return "Username is empty. Please fill Power BI username in web.config";
+                return "Invalid AuthorityUrl. Please fill Tenant ID in AuthorityUrl under web.config";
             }
 
-            // Password must have a value.
-            if (string.IsNullOrWhiteSpace(Password))
+            if (AuthenticationType.Equals("MasterUser"))
             {
-                return "Password is empty. Please fill password of Power BI username in web.config";
+                // Username must have a value.
+                if (string.IsNullOrWhiteSpace(Username))
+                {
+                    return "Username is empty. Please fill Power BI username in web.config";
+                }
+
+                // Password must have a value.
+                if (string.IsNullOrWhiteSpace(Password))
+                {
+                    return "Password is empty. Please fill password of Power BI username in web.config";
+                }
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(ApplicationSecret))
+                {
+                    return "ApplicationSecret is empty. please register your application as Web app and fill appSecret in web.config.";
+                }
             }
 
             return null;

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
@@ -332,7 +332,7 @@ namespace PowerBIEmbedded_AppOwnsData.Services
             else
             {
                 // Authentication using app credentials
-                ClientCredential clientCredential = new ClientCredential(ApplicationId, ApplicationSecret);
+                var credential = new ClientCredential(ApplicationId, ApplicationSecret);
                 authenticationResult = await authenticationContext.AcquireTokenAsync(ResourceUrl, clientCredential);
             }
 
@@ -348,9 +348,6 @@ namespace PowerBIEmbedded_AppOwnsData.Services
                 m_embedConfig.ErrorMessage = error;
                 return false;
             }
-
-            // Create a user password cradentials.
-            var credential = new UserPasswordCredential(Username, Password);
 
             // Authenticate using created credentials
             AuthenticationResult authenticationResult = null;
@@ -369,10 +366,8 @@ namespace PowerBIEmbedded_AppOwnsData.Services
                 m_embedConfig.ErrorMessage = "Authentication Failed.";
                 return false;
             }
-            var authenticationContext = new AuthenticationContext(AuthorityUrl);
 
             m_tokenCredentials = new TokenCredentials(authenticationResult.AccessToken, "Bearer");
-
             return true;
         }
     }

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
@@ -25,7 +25,6 @@ namespace PowerBIEmbedded_AppOwnsData.Services
         private static readonly string Username = ConfigurationManager.AppSettings["pbiUsername"];
         private static readonly string Password = ConfigurationManager.AppSettings["pbiPassword"];
 
-
         public EmbedConfig EmbedConfig
         {
             get { return m_embedConfig; }

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -17,7 +17,6 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
 
-    <!-- Common configuration properties for both authentication types -->
     <add key="applicationId" value="" />
     <add key="workspaceId" value=""/>
     <!-- The id of the report to embed. If empty, will use the first report in group -->

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -17,11 +17,6 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
 
-    <!-- Two possible Autentication method: 
-          - For authentication with master user credential choose MasterUser as AuthenticationType.
-          - For authentication with app secret choose MasterUser as ServicePrincipal
-        -->
-    <add key="AuthenticationType" value="MasterUser" />
     <!-- Common configuration properties for both authentication types -->
     <add key="applicationId" value="" />
     <add key="workspaceId" value=""/>
@@ -33,19 +28,11 @@
     <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
     <add key="apiUrl" value="https://api.powerbi.com/" />
     <add key="embedUrlBase" value="https://app.powerbi.com/" />
-  </appSettings>
-
-  <MasterUser>
     <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
     <add key="pbiUsername" value=""/>
     <add key="pbiPassword" value=""/>
-  </MasterUser>
+  </appSettings>
 
-  <ServicePrincipal>
-    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
-    <add key="applicationSecret" value="" />
-  </ServicePrincipal>
-  
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -16,26 +16,8 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="AuthenticationType" value="AppOnly" />
+    <add key="AuthenticationType" value="MasterUser" />
   </appSettings>
-
-  <ServicePrinciple>
-    <add key="applicationId" value="" />
-    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
-    <add key="applicationSecret" value="" />
-
-    <add key="workspaceId" value=""/>
-    <!-- The id of the report to embed. If empty, will use the first report in group -->
-    <add key="reportId" value=""/>
-    <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
-    <add key="pbiUsername" value=""/>
-    <add key="pbiPassword" value=""/>
-
-    <add key="authorityUrl" value="https://login.microsoftonline.com/faae7f19-77f3-4fcc-bdaa-487b920cb7ee/oauth2/authorize" />
-    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
-    <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
-    <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
-  </ServicePrinciple>
 
   <MasterUser>
     <add key="applicationId" value="" />
@@ -54,6 +36,25 @@
     <add key="apiUrl" value="https://api.powerbi.com/" />
     <add key="embedUrlBase" value="https://app.powerbi.com/" />
   </MasterUser>
+
+  <ServicePrinciple>
+    <add key="applicationId" value="" />
+    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
+    <add key="applicationSecret" value="" />
+
+    <add key="workspaceId" value=""/>
+    <!-- The id of the report to embed. If empty, will use the first report in group -->
+    <add key="reportId" value=""/>
+    <!-- Note: credentials can be empty in this authentication method. -->
+    <add key="pbiUsername" value=""/>
+    <add key="pbiPassword" value=""/>
+
+    <add key="authorityUrl" value="https://login.microsoftonline.com/faae7f19-77f3-4fcc-bdaa-487b920cb7ee/oauth2/authorize" />
+    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
+    <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
+    <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
+  </ServicePrinciple>
+  
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -27,7 +27,6 @@
     <add key="pbiUsername" value="" />
     <add key="pbiPassword" value="" />
   </appSettings>
-
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -6,21 +6,17 @@
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
-    <section name="ServicePrincipal" type="System.Configuration.NameValueSectionHandler" />
-    <section name="MasterUser" type="System.Configuration.NameValueSectionHandler" />
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
-
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-
     <add key="applicationId" value="" />
-    <add key="workspaceId" value=""/>
+    <add key="workspaceId" value="" />
     <!-- The id of the report to embed. If empty, will use the first report in group -->
-    <add key="reportId" value=""/>
+    <add key="reportId" value="" />
 
     <!-- Fill Tenant ID in authorityUrl-->
     <add key="authorityUrl" value="https://login.microsoftonline.com/Fill_Tenant_ID/oauth2/authorize" />
@@ -28,8 +24,8 @@
     <add key="apiUrl" value="https://api.powerbi.com/" />
     <add key="embedUrlBase" value="https://app.powerbi.com/" />
     <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
-    <add key="pbiUsername" value=""/>
-    <add key="pbiPassword" value=""/>
+    <add key="pbiUsername" value="" />
+    <add key="pbiPassword" value="" />
   </appSettings>
 
   <!--

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -16,7 +16,11 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    
+
+    <!-- Two possible Autentication method: 
+          - For authentication with master user credential choose MasterUser as AuthenticationType.
+          - For authentication with app secret choose MasterUser as ServicePrincipal
+        -->
     <add key="AuthenticationType" value="MasterUser" />
     <!-- Common configuration properties for both authentication types -->
     <add key="applicationId" value="" />
@@ -24,7 +28,8 @@
     <!-- The id of the report to embed. If empty, will use the first report in group -->
     <add key="reportId" value=""/>
 
-    <add key="authorityUrl" value="https://login.microsoftonline.com/Fill Tenant ID/oauth2/authorize" />
+    <!-- Fill Tenant ID in authorityUrl-->
+    <add key="authorityUrl" value="https://login.microsoftonline.com/Fill_Tenant_ID/oauth2/authorize" />
     <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
     <add key="apiUrl" value="https://api.powerbi.com/" />
     <add key="embedUrlBase" value="https://app.powerbi.com/" />

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -7,8 +7,8 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
-    <section name="AppOnly" type="System.Configuration.NameValueSectionHandler" />
-    <section name="AppOwnsData" type="System.Configuration.NameValueSectionHandler" />
+    <section name="ServicePrinciple" type="System.Configuration.NameValueSectionHandler" />
+    <section name="MasterUser" type="System.Configuration.NameValueSectionHandler" />
   </configSections>
 
   <appSettings>
@@ -19,7 +19,7 @@
     <add key="AuthenticationType" value="AppOnly" />
   </appSettings>
 
-  <AppOnly>
+  <ServicePrinciple>
     <add key="applicationId" value="" />
     <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
     <add key="applicationSecret" value="" />
@@ -35,9 +35,9 @@
     <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
     <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
     <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
-  </AppOnly>
+  </ServicePrinciple>
 
-  <AppOwnsData>
+  <MasterUser>
     <add key="applicationId" value="" />
     <!-- Note: applicationSecret can be empty in this authentication method -->
     <add key="applicationSecret" value="" />
@@ -53,7 +53,7 @@
     <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
     <add key="apiUrl" value="https://api.powerbi.com/" />
     <add key="embedUrlBase" value="https://app.powerbi.com/" />
-  </AppOwnsData>
+  </MasterUser>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -7,20 +7,53 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="AppOnly" type="System.Configuration.NameValueSectionHandler" />
+    <section name="AppOwnsData" type="System.Configuration.NameValueSectionHandler" />
   </configSections>
-  <appSettings file="Cloud.config">
-    <add key="webpages:Version" value="3.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
-    <add key="applicationId" value=""/>
+
+  <appSettings>
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="AuthenticationType" value="AppOnly" />
+  </appSettings>
+
+  <AppOnly>
+    <add key="applicationId" value="" />
+    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
+    <add key="applicationSecret" value="" />
+
     <add key="workspaceId" value=""/>
     <!-- The id of the report to embed. If empty, will use the first report in group -->
     <add key="reportId" value=""/>
     <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
     <add key="pbiUsername" value=""/>
     <add key="pbiPassword" value=""/>
-  </appSettings>
+
+    <add key="authorityUrl" value="https://login.microsoftonline.com/faae7f19-77f3-4fcc-bdaa-487b920cb7ee/oauth2/authorize" />
+    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
+    <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
+    <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
+  </AppOnly>
+
+  <AppOwnsData>
+    <add key="applicationId" value="" />
+    <!-- Note: applicationSecret can be empty in this authentication method -->
+    <add key="applicationSecret" value="" />
+
+    <add key="workspaceId" value=""/>
+    <!-- The id of the report to embed. If empty, will use the first report in group -->
+    <add key="reportId" value=""/>
+    <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
+    <add key="pbiUsername" value=""/>
+    <add key="pbiPassword" value=""/>
+
+    <add key="authorityUrl" value="https://login.windows.net/common/oauth2/authorize/" />
+    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
+    <add key="apiUrl" value="https://api.powerbi.com/" />
+    <add key="embedUrlBase" value="https://app.powerbi.com/" />
+  </AppOwnsData>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/Web.config
@@ -7,7 +7,7 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
-    <section name="ServicePrinciple" type="System.Configuration.NameValueSectionHandler" />
+    <section name="ServicePrincipal" type="System.Configuration.NameValueSectionHandler" />
     <section name="MasterUser" type="System.Configuration.NameValueSectionHandler" />
   </configSections>
 
@@ -16,44 +16,30 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    
     <add key="AuthenticationType" value="MasterUser" />
-  </appSettings>
-
-  <MasterUser>
+    <!-- Common configuration properties for both authentication types -->
     <add key="applicationId" value="" />
-    <!-- Note: applicationSecret can be empty in this authentication method -->
-    <add key="applicationSecret" value="" />
-
     <add key="workspaceId" value=""/>
     <!-- The id of the report to embed. If empty, will use the first report in group -->
     <add key="reportId" value=""/>
-    <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
-    <add key="pbiUsername" value=""/>
-    <add key="pbiPassword" value=""/>
 
-    <add key="authorityUrl" value="https://login.windows.net/common/oauth2/authorize/" />
+    <add key="authorityUrl" value="https://login.microsoftonline.com/Fill Tenant ID/oauth2/authorize" />
     <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
     <add key="apiUrl" value="https://api.powerbi.com/" />
     <add key="embedUrlBase" value="https://app.powerbi.com/" />
-  </MasterUser>
+  </appSettings>
 
-  <ServicePrinciple>
-    <add key="applicationId" value="" />
-    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
-    <add key="applicationSecret" value="" />
-
-    <add key="workspaceId" value=""/>
-    <!-- The id of the report to embed. If empty, will use the first report in group -->
-    <add key="reportId" value=""/>
-    <!-- Note: credentials can be empty in this authentication method. -->
+  <MasterUser>
+    <!-- Note: Do NOT leave your credentials on code. Save them in secure place. -->
     <add key="pbiUsername" value=""/>
     <add key="pbiPassword" value=""/>
+  </MasterUser>
 
-    <add key="authorityUrl" value="https://login.microsoftonline.com/faae7f19-77f3-4fcc-bdaa-487b920cb7ee/oauth2/authorize" />
-    <add key="resourceUrl" value="https://analysis.windows.net/powerbi/api" />
-    <add key="apiUrl" value="https://powerbistagingapi.analysis.windows.net" />
-    <add key="embedUrlBase" value="https://wabi-staging-us-east-redirect.analysis.windows.net" />
-  </ServicePrinciple>
+  <ServicePrincipal>
+    <!-- Note: Do NOT leave your app secret on code. Save it in secure place. -->
+    <add key="applicationSecret" value="" />
+  </ServicePrincipal>
   
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/packages.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/packages.config
@@ -16,14 +16,6 @@
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.Net.Compilers" version="2.10.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.Owin" version="4.0.0" targetFramework="net461" />
-  <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Security.Facebook" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Security.Google" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Security.MicrosoftAccount" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Security.Twitter" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.PowerBI.Api" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.PowerBI.JavaScript" version="2.6.6" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.18" targetFramework="net461" />

--- a/App Owns Data/PowerBIEmbedded_AppOwnsData/packages.config
+++ b/App Owns Data/PowerBIEmbedded_AppOwnsData/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net452" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.Net.Compilers" version="2.10.0" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin" version="4.0.0" targetFramework="net461" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net452" />

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For security reasons, in real application, don't save the user and password in w
 Please follow these steps to run PowerBI.com Integrate samples:
 ## Step 1 - App Registration
 You need to register an application in
-https://app.powerbi.com/embedsetup
+https://app.powerbi.com/embedsetup/UserOwnsData
 
 ### Registration parameters per sample
 

--- a/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx
+++ b/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx
@@ -72,7 +72,7 @@
             <br />
             First make sure you <a href="https://dev.powerbi.com/apps">register your app</a>. After registration, copy <u>Client ID</u> and <u>Client Secret</u> to web.config file.
             <br />
-            The application will embed the first report from your Power BI account. If you wish to embed a specific report, please copy the report's Report ID and corresponding Group ID to web.config file.
+            The application will embed the first report from your Power BI account. If you wish to embed a specific report, please copy the report's ID and the corresponding group ID to web.config file.
         </h2>
     </header>
 

--- a/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx.cs
+++ b/User Owns Data/integrate-report-web-app/PBIWebApp/Default.aspx.cs
@@ -95,7 +95,7 @@ namespace PBIWebApp
                 else
                 {
                     report = client.Reports.GetReports().Value.FirstOrDefault(r => r.Id == reportId);
-                    AppendErrorIfReportNull(report, string.Format("Report with ID: {0} not found. Please check the report ID. For reports within a group with a group ID, add the group ID to the application's settings", reportId));
+                    AppendErrorIfReportNull(report, string.Format("Report with ID: '{0}' not found. Please check the report ID. For reports within a group with a group ID, add the group ID to the application's settings", reportId));
                 }
 
                 if (report != null)
@@ -176,7 +176,7 @@ namespace PBIWebApp
             // No group with the group ID was found.
             if (sourceGroup == null)
             {
-                errorLabel.Text = string.Format("Group with id: {0} not found. Please validate the provided group ID.", groupId);
+                errorLabel.Text = string.Format("Group with id: '{0}' not found. Please validate the provided group ID.", groupId);
                 return null;
             }
 
@@ -198,7 +198,7 @@ namespace PBIWebApp
 
                 catch(HttpOperationException)
                 {
-                    errorLabel.Text = string.Format("Report with ID:{0} not found in the group {1}, Please check the report ID.", reportId, groupId);
+                    errorLabel.Text = string.Format("Report with ID: '{0}' not found in the group with ID: '{1}', Please check the report ID.", reportId, groupId);
 
                 }
             }


### PR DESCRIPTION
This branch contains several changes in the AppOwnsData sample:

**The major change is in the app structure -** 
 - Added a Service class
 - All data access moved from the main controller to the service class, the controller uses only to call the service and return the view to the user.

**Additional fixes - **
- Removed unnecessary Owin packages (not used in AppOwnsData, only in UserOwnsData sample app).
- Moved all configuration to Web.config (removed Cloud.config).
- Minor fix in Readme content regarding the link for creating an app.