### PR TITLE
Use built-in OpenID Connect authentication

### DIFF
--- a/.Net Core Sample/NetCore-Sample/AppSettings.cs
+++ b/.Net Core Sample/NetCore-Sample/AppSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace PowerBI_API_NetCore_Sample
+﻿namespace PowerBI_API_NetCore_Sample
 {
     public class AppSettings
     {
@@ -12,7 +7,6 @@ namespace PowerBI_API_NetCore_Sample
         public string RedirectUrl { get; set; }
         public string ApiUrl { get; set; }
         public string ApplicationId { get; set; }
-        public string LoggingRequestUrl { get; set; }
         public string GroupId { get; set; }
     }
 }

--- a/.Net Core Sample/NetCore-Sample/Pages/Error.cshtml.cs
+++ b/.Net Core Sample/NetCore-Sample/Pages/Error.cshtml.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace PowerBI_API_NetCore_Sample.Pages
@@ -14,12 +11,12 @@ namespace PowerBI_API_NetCore_Sample.Pages
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
-        public void OnGet()
+        public void OnGet([FromQuery]string message)
         {
             RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
-            if (PageContext.HttpContext.Request.Query.ContainsKey("message"))
+            if (!string.IsNullOrEmpty(message))
             {
-                Message = Request.Query["message"][0];
+                Message = message;
             }
         }
     }

--- a/.Net Core Sample/NetCore-Sample/Pages/Index.cshtml.cs
+++ b/.Net Core Sample/NetCore-Sample/Pages/Index.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.PowerBI.Api.V2;
 using Microsoft.PowerBI.Api.V2.Models;
@@ -22,13 +23,13 @@ namespace PowerBI_API_NetCore_Sample.Pages
             AppSettings = appSettings;
         }
 
-        public async Task OnGet()
+        public async Task<IActionResult> OnGet()
         {
             AccessToken = await HttpContext.GetTokenAsync("access_token");
-            await EmbedReport();
+            return await EmbedReport();
         }
 
-        private async Task EmbedReport()
+        private async Task<IActionResult> EmbedReport()
         {
             using (var client = new PowerBIClient(new Uri(AppSettings.ApiUrl), new TokenCredentials(AccessToken, "Bearer")))
             {
@@ -48,7 +49,7 @@ namespace PowerBI_API_NetCore_Sample.Pages
                 {
                     // no groups available for user
                     string message = "No group available, need to create a group and upload a report";
-                    Response.Redirect($"Error?message={message}");
+                    return Error(message);
                 }
 
                 // getting first report in selected group from GetReports results
@@ -64,9 +65,14 @@ namespace PowerBI_API_NetCore_Sample.Pages
                     // no reports available for user in chosen group
                     // need to upload a report or insert a specific group id in appsettings.json
                     string message = "No report available in workspace with ID " + groupId + ", Please fill a group id with existing report in appsettings.json file";
-                    Response.Redirect($"Error?message={message}");
+                    return Error(message);
                 }
             }
+
+            // Everything went fine, display the report
+            return Page();
+
+            IActionResult Error(string errorMessage) => RedirectToPage("Error", new { message = errorMessage });
         }
     }
 }

--- a/.Net Core Sample/NetCore-Sample/Pages/Index.cshtml.cs
+++ b/.Net Core Sample/NetCore-Sample/Pages/Index.cshtml.cs
@@ -1,65 +1,31 @@
 ﻿using System;
-using System.Collections.Specialized;
 using System.Linq;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
-using System.Web;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Configuration;
 using Microsoft.PowerBI.Api.V2;
 using Microsoft.PowerBI.Api.V2.Models;
 using Microsoft.Rest;
-using Newtonsoft.Json.Linq;
 
 namespace PowerBI_API_NetCore_Sample.Pages
 {
     public class IndexModel : PageModel
     {
-        public static string _accessToken;
         public string EmbedUrl { get; set; }
         public string AccessToken { get; set; }
         public string ReportId { get; set; }
 
         public AppSettings AppSettings { get; }
 
-        public IndexModel(IConfiguration configuration)
+        public IndexModel(AppSettings appSettings)
         {
-            AppSettings = configuration.GetSection("AppSettings").Get<AppSettings>();
+            AppSettings = appSettings;
         }
 
-        public void OnGet()
+        public async Task OnGet()
         {
-            if (Request.Query.ContainsKey("code"))
-            {
-                if (_accessToken == null)
-                {
-                    var authCode = Request.Query["code"][0];
-                    Task.Run(async () => await GetAccessToken(authCode)).Wait();
-                    AccessToken = _accessToken;
-                    Task.Run(async () => await EmbedReport()).Wait();
-                }
-                else
-                {
-                    // handle refresh in web page
-                    AccessToken = _accessToken;
-                    Task.Run(async () => await EmbedReport()).Wait();
-                }
-            }
-            else
-            {
-                var errorMessage = VerifySettings();
-                if (string.IsNullOrEmpty(errorMessage))
-                {
-                    GetAuthorizationCode();
-                }
-                else
-                {
-                    // error in settings
-                    Response.Redirect($"Error?message={errorMessage}");
-                }
-            }
+            AccessToken = await HttpContext.GetTokenAsync("access_token");
+            await EmbedReport();
         }
 
         private async Task EmbedReport()
@@ -101,108 +67,6 @@ namespace PowerBI_API_NetCore_Sample.Pages
                     Response.Redirect($"Error?message={message}");
                 }
             }
-        }
-
-        private void GetAuthorizationCode()
-        {
-            var queryParams = new NameValueCollection
-            {
-                // Azure AD will return an authorization code. 
-                {"response_type", "code"},
-
-                // Client ID is used by the application to identify themselves to the users that they are requesting permissions from. 
-                // You get the client id when you register your Azure app.
-                {"client_id", AppSettings.ApplicationId},
-
-                // Resource uri to the Power BI resource to be authorized
-                // The resource uri is hard-coded for sample purposes
-                {"resource", AppSettings.ResourceUrl},
-
-                // After app authenticates, Azure AD will redirect back to the web app. In this sample, Azure AD redirects back
-                // to Default page (Default.aspx).
-                { "redirect_uri", AppSettings.RedirectUrl}
-            };
-
-            // Create sign-in query string
-            var queryString = HttpUtility.ParseQueryString(string.Empty);
-            queryString.Add(queryParams);
-
-            // Redirect to Azure AD Authority
-            //  Authority Uri is an Azure resource that takes a application id and application secret to get an Access token
-            //  QueryString contains 
-            //      response_type of "code"
-            //      client_id that identifies your app in Azure AD
-            //      resource which is the Power BI API resource to be authorized
-            //      redirect_uri which is the uri that Azure AD will redirect back to after it authenticates
-
-            // Redirect to Azure AD to get an authorization code
-            Response.Redirect($"{AppSettings.AuthorityUri} ?{queryString}");
-        }
-
-        private async Task GetAccessToken(string authCode)
-        {
-            using (var httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
-
-                var requestBody = $"resource={HttpUtility.UrlEncode(AppSettings.ResourceUrl)}" +
-                                  $"&redirect_uri=" + AppSettings.RedirectUrl +
-                                  $"&client_id={AppSettings.ApplicationId}" +
-                                  $"&grant_type=authorization_code" +
-                                  $"&code = " + authCode;
-
-                using (var response = await httpClient.PostAsync(AppSettings.LoggingRequestUrl,
-                    new StringContent(requestBody, Encoding.UTF8, "application/x-www-form-urlencoded")))
-                {
-                    if (response.IsSuccessStatusCode)
-                    {
-                        var result = JObject.Parse(await response.Content.ReadAsStringAsync());
-                        _accessToken = result.Value<string>("access_token");
-                    }
-                    else
-                    {
-                        Response.Redirect("Error?message=Can't get access token");
-                    }
-                }
-            }
-        }
-
-        private string VerifySettings()
-        {
-            string message = null;
-            Guid result;
-
-            // Application Id must have a value.
-            if (string.IsNullOrWhiteSpace(AppSettings.ApplicationId))
-            {
-                message = "ApplicationId is empty. please register your application as Native app in https://dev.powerbi.com/apps and fill application Id in appsettings.json";
-            }
-            else
-            {
-                // Application Id must be a Guid object.
-                if (!Guid.TryParse(AppSettings.ApplicationId, out result))
-                {
-                    message = "ApplicationId must be a Guid object. please register your application as Native app in https://dev.powerbi.com/apps and fill application Id in appsettings.json";
-                }
-            }
-
-            // Workspace Id must be a Guid object.
-            if (!string.IsNullOrWhiteSpace(AppSettings.GroupId))
-            {
-                if (!Guid.TryParse(AppSettings.GroupId, out result))
-                {
-                    message = "GroupId must be a Guid object. Please select a group you own and fill its Id in appsettings.json";
-                }
-            }
-
-            // All urls must have value
-            if (string.IsNullOrWhiteSpace(AppSettings.ApiUrl) || string.IsNullOrWhiteSpace(AppSettings.AuthorityUri) ||
-                string.IsNullOrWhiteSpace(AppSettings.RedirectUrl) || string.IsNullOrWhiteSpace(AppSettings.ResourceUrl) || string.IsNullOrWhiteSpace(AppSettings.LoggingRequestUrl))
-            {
-                message = "One or more of the urls required are missing. Please check appsettings.json file. for more info check sample instructions in https://github.com/Microsoft/PowerBI-Developer-Samples";
-            }
-
-            return message;
         }
     }
 }

--- a/.Net Core Sample/NetCore-Sample/Properties/launchSettings.json
+++ b/.Net Core Sample/NetCore-Sample/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:21639/"
+      "applicationUrl": "http://localhost:21638/"
     }
   }
 }

--- a/.Net Core Sample/NetCore-Sample/Startup.cs
+++ b/.Net Core Sample/NetCore-Sample/Startup.cs
@@ -1,11 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace PowerBI_API_NetCore_Sample
 {
@@ -21,7 +22,79 @@ namespace PowerBI_API_NetCore_Sample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            var appSettings = Configuration.GetSection("AppSettings").Get<AppSettings>();
+            services.AddSingleton(appSettings);
+
+            services
+                .AddAuthentication(options =>
+                {
+                    options.DefaultScheme = "Cookies";
+                    options.DefaultChallengeScheme = "AzureAD";
+                })
+                .AddCookie("Cookies")
+                .AddOpenIdConnect("AzureAD", options =>
+                {
+                    // Specify we want the user to be redirect to Azure AD to authenticate themselves
+                    options.Authority = appSettings.AuthorityUri;
+
+                    // Client ID is used by the application to identify themselves to the users that they are requesting permissions from.
+                    // You get the client id when you register your Azure app
+                    options.ClientId = appSettings.ApplicationId;
+
+                    // Azure AD will return an authorization code.
+                    options.ResponseType = OpenIdConnectResponseType.Code;
+
+                    // After app authenticates, Azure AD will redirect back to the web app. In this sample, Azure AD redirects back
+                    // to Default page, which is the root of the application (/)
+                    options.CallbackPath = new PathString("/");
+
+                    // Indicate we want to save the access token in the session cookie
+                    options.SaveTokens = true;
+
+                    // Disable issuer validation as we can't know in advance which Azure AD tenant
+                    // the user will log in with
+                    options.TokenValidationParameters.ValidateIssuer = false;
+
+                    // The root of the application, /, has 2 purposes:
+                    //  - serve the default page by MVC, Index.cshtml; and
+                    //  - process the data returned by Azure AD after the user authenticates (this is set when configuring the Azure app)
+                    //
+                    // Because of that, we need to indicate to the OpenID Connect handler that not all requests will contain an OpenID Connect message
+                    options.SkipUnrecognizedRequests = true;
+
+                    // SkipUnrecognizedRequests doesn't behave correctly in ASP.NET Core 2.x
+                    // Fixed in ASP.NET Core 3.x
+                    // See https://github.com/aspnet/AspNetCore/pull/10060
+                    options.Events.OnMessageReceived = context =>
+                    {
+                        if (context.Properties.Items.Count == 0)
+                        {
+                            context.SkipHandler();
+                        }
+
+                        return Task.CompletedTask;
+                    };
+
+                    options.Events.OnRedirectToIdentityProvider = context =>
+                    {
+                        // Before the user is redirected to Azure AD, indicate what resource we're interested in accessing
+                        // Resource uri to the Power BI resource to be authorized
+                        // The resource uri is hard-coded for sample purposes
+                        context.ProtocolMessage.Resource = appSettings.ResourceUrl;
+                        return Task.CompletedTask;
+                    };
+                });
+
+            services.AddMvc(options =>
+            {
+                // Use MVC global filters to indicate every single request must be authenticated
+                // This is what will redirect users to Azure AD on their first request
+                var requireAuthenticatedUsersPolicy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build();
+
+                options.Filters.Add(new AuthorizeFilter(requireAuthenticatedUsersPolicy));
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -38,7 +111,7 @@ namespace PowerBI_API_NetCore_Sample
             }
 
             app.UseStaticFiles();
-
+            app.UseAuthentication();
             app.UseMvc();
         }
     }

--- a/.Net Core Sample/NetCore-Sample/appsettings.json
+++ b/.Net Core Sample/NetCore-Sample/appsettings.json
@@ -1,11 +1,10 @@
 ﻿{
   "AppSettings": {
-    "AuthorityUri": "https://login.windows.net/common/oauth2/authorize/",
+    "AuthorityUri": "https://login.microsoftonline.com/common",
     "ResourceUrl": "https://analysis.windows.net/powerbi/api",
     "RedirectUrl": "http://localhost:21638",
     "ApiUrl": "https://api.powerbi.com/",
     "ApplicationId": "7d2382e0-67a3-44b8-b0d9-423e079c8e73",
-    "LoggingRequestUrl": "https://login.microsoftonline.com/common/oauth2/token",
     "GroupId": ""
   },
   "Logging": {


### PR DESCRIPTION
Hi there 👋

## TL;DR; breakdown by commits

1. use OpenID Connect authentication
1. leverage MVC capabilities
1. fix the sample when not running in IIS Express

## Longer version 

### 1. Use OpenID Connect authentication
 
I noticed this sample implements an OpenID Connect flow manually.
While I appreciate this is a sample to show how to embed Power BI reports, I think rolling your own authentication is never a good idea, and I'm afraid people might use this implementation in their projects.

The main goal of this PR is to take advantage of the great authentication system in ASP.NET Core and leverage the OpenID Connect provider to delegate authentication to Azure AD.

There are small hacks &mdash; that I'll highlight as comments in this PR &mdash; because the redirect URL configured in the Azure AD application is set to the root of the application, `http://localhost:21638`. The recommendation is to use dedicated endpoints as redirect URLs because by default, the OIDC provider assumes all requests to the redirect URL will contain some sort of OpenID Connect message, which is not the case here as it also serves the page that embeds the Power BI report.
I'm not sure whether you have control over the app registration in Azure, but using something more common like `http://localhost:21638/signin-oidc` would greatly reduce the complexity of this sample; you can leave the existing redirect URL as-is to not break the experience for people who have already cloned or forked this repository.

### 2. Leverage MVC capabilities

Other small changes leverage the capabilities of ASP.NET Core MVC to redirect to a page or get the error message in the error page.

### 3. Fix the sample when not running in IIS Express

The `launchsettings.json` file describes which URLs are used when the project is run both in IIS Express and directly in the console through the Kestrel web server.
The application is hosted over a different port, `21639`, when running in Kestrel, which means when Azure AD tried to redirect the user to `http://localhost:21638`, there's no application running on that port.