### PR TITLE
Fix a bug when rendering a paginated report (clean)

### DIFF
--- a/.NET Framework/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
+++ b/.NET Framework/App Owns Data/PowerBIEmbedded_AppOwnsData/Services/EmbedService.cs
@@ -103,12 +103,16 @@ namespace PowerBIEmbedded_AppOwnsData.Services
                         return false;
                     }
 
-                    var datasets = await client.Datasets.GetDatasetInGroupAsync(WorkspaceId, report.DatasetId);
-                    m_embedConfig.IsEffectiveIdentityRequired = datasets.IsEffectiveIdentityRequired;
-                    m_embedConfig.IsEffectiveIdentityRolesRequired = datasets.IsEffectiveIdentityRolesRequired;
+                    if (report.DatasetId != null)
+                    {
+                        var datasets = await client.Datasets.GetDatasetInGroupAsync(WorkspaceId, report.DatasetId);
+                        m_embedConfig.IsEffectiveIdentityRequired = datasets.IsEffectiveIdentityRequired;
+                        m_embedConfig.IsEffectiveIdentityRolesRequired = datasets.IsEffectiveIdentityRolesRequired;
+                    }
+
                     GenerateTokenRequest generateTokenRequestParameters;
                     // This is how you create embed token with effective identities
-                    if (!string.IsNullOrWhiteSpace(username))
+                    if (!string.IsNullOrWhiteSpace(username) && report.DatasetId != null)
                     {
                         var rls = new EffectiveIdentity(username, new List<string> { report.DatasetId });
                         if (!string.IsNullOrWhiteSpace(roles))


### PR DESCRIPTION
@parth-007, I created this new PR because the other one (#104) was too confused.
----
When we use a paginated report, it does not have a DataSet on it, causing this Sample application to crash.
We added an "if" statement to validate if the current report has a DataSet avoiding the error.