### PR TITLE
identities field added to EmbedTokenRequestBody for Row-level security.

### DIFF
--- a/Python/Embed for your customers/AppOwnsData/app.py
+++ b/Python/Embed for your customers/AppOwnsData/app.py
@@ -6,6 +6,7 @@ from utils import Utils
 from flask import Flask, render_template, send_from_directory
 import json
 import os
+from models.identity import Identity
 
 # Initialize the Flask app
 app = Flask(__name__)
@@ -27,8 +28,15 @@ def get_embed_info():
     if config_result is not None:
         return json.dumps({'errorMsg': config_result}), 500
 
+    # For Row-level security [https://docs.microsoft.com/en-us/power-bi/developer/embedded/embedded-row-level-security]
+    # identity = Identity()
+    # identity.username = 'Andrew Ma'
+    # identity.roles = ['Manager']
+    # identities = [identity]
+    identities = None
+
     try:
-        embed_info = PbiEmbedService().get_embed_params_for_single_report(app.config['WORKSPACE_ID'], app.config['REPORT_ID'])
+        embed_info = PbiEmbedService().get_embed_params_for_single_report(app.config['WORKSPACE_ID'], app.config['REPORT_ID'], identities=identities)
         return embed_info
     except Exception as ex:
         return json.dumps({'errorMsg': str(ex)}), 500

--- a/Python/Embed for your customers/AppOwnsData/models/embedtokenrequestbody.py
+++ b/Python/Embed for your customers/AppOwnsData/models/embedtokenrequestbody.py
@@ -8,6 +8,7 @@ class EmbedTokenRequestBody:
     datasets = None
     reports = None
     targetWorkspaces = None
+    identities = None
 
     def __init__(self):
         self.datasets = []

--- a/Python/Embed for your customers/AppOwnsData/models/identity.py
+++ b/Python/Embed for your customers/AppOwnsData/models/identity.py
@@ -1,0 +1,27 @@
+class Identity:
+    customData = None
+    datasets = None
+    identityBlob = None
+    reports = None
+    roles = None
+    username = None
+
+    def __init__(self):
+        self.datasets = []
+        self.roles = []
+        self.username = ''
+
+    def get_dict(self):
+        output = self.__dict__
+
+        if self.identityBlob is not None:
+            output['identityBlob'] = self.identityBlob.__dict__
+
+        return output
+
+
+class IdentityBlob:
+    value = None
+
+    def __init__(self):
+        self.value = ''

--- a/Python/Embed for your customers/AppOwnsData/services/pbiembedservice.py
+++ b/Python/Embed for your customers/AppOwnsData/services/pbiembedservice.py
@@ -12,19 +12,20 @@ import json
 
 class PbiEmbedService:
 
-    def get_embed_params_for_single_report(self, workspace_id, report_id, additional_dataset_id=None):
+    def get_embed_params_for_single_report(self, workspace_id, report_id, additional_dataset_id=None, identities=None):
         '''Get embed params for a report and a workspace
 
         Args:
             workspace_id (str): Workspace Id
             report_id (str): Report Id
             additional_dataset_id (str, optional): Dataset Id different than the one bound to the report. Defaults to None.
+            identities (list|None): Identity List
 
         Returns:
             EmbedConfig: Embed token and Embed URL
         '''
 
-        report_url = f'https://api.powerbi.com/v1.0/myorg/groups/{workspace_id}/reports/{report_id}'       
+        report_url = f'https://api.powerbi.com/v1.0/myorg/groups/{workspace_id}/reports/{report_id}'
         api_response = requests.get(report_url, headers=self.get_request_header())
 
         if api_response.status_code != 200:
@@ -38,17 +39,18 @@ class PbiEmbedService:
         if additional_dataset_id is not None:
             dataset_ids.append(additional_dataset_id)
 
-        embed_token = self.get_embed_token_for_single_report_single_workspace(report_id, dataset_ids, workspace_id)
+        embed_token = self.get_embed_token_for_single_report_single_workspace(report_id, dataset_ids, workspace_id, identities)
         embed_config = EmbedConfig(embed_token.tokenId, embed_token.token, embed_token.tokenExpiry, [report.__dict__])
         return json.dumps(embed_config.__dict__)
 
-    def get_embed_params_for_multiple_reports(self, workspace_id, report_ids, additional_dataset_ids=None):
+    def get_embed_params_for_multiple_reports(self, workspace_id, report_ids, additional_dataset_ids=None, identities=None):
         '''Get embed params for multiple reports for a single workspace
 
         Args:
             workspace_id (str): Workspace Id
             report_ids (list): Report Ids
             additional_dataset_ids (list, optional): Dataset Ids which are different than the ones bound to the reports. Defaults to None.
+            identities (list|None): Identity List
 
         Returns:
             EmbedConfig: Embed token and Embed URLs
@@ -77,17 +79,18 @@ class PbiEmbedService:
         if additional_dataset_ids is not None:
             dataset_ids.extend(additional_dataset_ids)
 
-        embed_token = self.get_embed_token_for_multiple_reports_single_workspace(report_ids, dataset_ids, workspace_id)
+        embed_token = self.get_embed_token_for_multiple_reports_single_workspace(report_ids, dataset_ids, workspace_id, identities)
         embed_config = EmbedConfig(embed_token.tokenId, embed_token.token, embed_token.tokenExpiry, reports)
         return json.dumps(embed_config.__dict__)
 
-    def get_embed_token_for_single_report_single_workspace(self, report_id, dataset_ids, target_workspace_id=None):
+    def get_embed_token_for_single_report_single_workspace(self, report_id, dataset_ids, target_workspace_id=None, identities=None):
         '''Get Embed token for single report, multiple datasets, and an optional target workspace
 
         Args:
             report_id (str): Report Id
             dataset_ids (list): Dataset Ids
             target_workspace_id (str, optional): Workspace Id. Defaults to None.
+            identities (list|None): Identity List
 
         Returns:
             EmbedToken: Embed token
@@ -103,6 +106,14 @@ class PbiEmbedService:
         if target_workspace_id is not None:
             request_body.targetWorkspaces.append({'id': target_workspace_id})
 
+        if identities is not None:
+            request_body.identities = []
+
+            for identity in identities:
+                identity.datasets = dataset_ids
+
+                request_body.identities.append(identity.get_dict())
+
         # Generate Embed token for multiple workspaces, datasets, and reports. Refer https://aka.ms/MultiResourceEmbedToken
         embed_token_api = 'https://api.powerbi.com/v1.0/myorg/GenerateToken'
         api_response = requests.post(embed_token_api, data=json.dumps(request_body.__dict__), headers=self.get_request_header())
@@ -114,13 +125,14 @@ class PbiEmbedService:
         embed_token = EmbedToken(api_response['tokenId'], api_response['token'], api_response['expiration'])
         return embed_token
 
-    def get_embed_token_for_multiple_reports_single_workspace(self, report_ids, dataset_ids, target_workspace_id=None):
+    def get_embed_token_for_multiple_reports_single_workspace(self, report_ids, dataset_ids, target_workspace_id=None, identities=None):
         '''Get Embed token for multiple reports, multiple dataset, and an optional target workspace
 
         Args:
             report_ids (list): Report Ids
             dataset_ids (list): Dataset Ids
             target_workspace_id (str, optional): Workspace Id. Defaults to None.
+            identities (list|None): Identity List
 
         Returns:
             EmbedToken: Embed token
@@ -139,24 +151,33 @@ class PbiEmbedService:
         if target_workspace_id is not None:
             request_body.targetWorkspaces.append({'id': target_workspace_id})
 
+        if identities is not None:
+            request_body.identities = []
+
+            for identity in identities:
+                identity.datasets = dataset_ids
+
+                request_body.identities.append(identity.get_dict())
+
         # Generate Embed token for multiple workspaces, datasets, and reports. Refer https://aka.ms/MultiResourceEmbedToken
         embed_token_api = 'https://api.powerbi.com/v1.0/myorg/GenerateToken'
         api_response = requests.post(embed_token_api, data=json.dumps(request_body.__dict__), headers=self.get_request_header())
 
         if api_response.status_code != 200:
             abort(api_response.status_code, description=f'Error while retrieving Embed token\n{api_response.reason}:\t{api_response.text}\nRequestId:\t{api_response.headers.get("RequestId")}')
-        
+
         api_response = json.loads(api_response.text)
         embed_token = EmbedToken(api_response['tokenId'], api_response['token'], api_response['expiration'])
         return embed_token
 
-    def get_embed_token_for_multiple_reports_multiple_workspaces(self, report_ids, dataset_ids, target_workspace_ids=None):
+    def get_embed_token_for_multiple_reports_multiple_workspaces(self, report_ids, dataset_ids, target_workspace_ids=None, identities=None):
         '''Get Embed token for multiple reports, multiple datasets, and optional target workspaces
 
         Args:
             report_ids (list): Report Ids
             dataset_ids (list): Dataset Ids
             target_workspace_ids (list, optional): Workspace Ids. Defaults to None.
+            identities (list|None): Identity List
 
         Returns:
             EmbedToken: Embed token
@@ -175,6 +196,14 @@ class PbiEmbedService:
         if target_workspace_ids is not None:
             for target_workspace_id in target_workspace_ids:
                 request_body.targetWorkspaces.append({'id': target_workspace_id})
+
+        if identities is not None:
+            request_body.identities = []
+
+            for identity in identities:
+                identity.datasets = dataset_ids
+
+                request_body.identities.append(identity.get_dict())
 
         # Generate Embed token for multiple workspaces, datasets, and reports. Refer https://aka.ms/MultiResourceEmbedToken
         embed_token_api = 'https://api.powerbi.com/v1.0/myorg/GenerateToken'


### PR DESCRIPTION
There were no identities in embedtokenrequestbody.py for row-level secure and therefore the feature was not available, it is now available.