### PR TITLE
Improve node app error message

### DIFF
--- a/NodeJS/Embed for your customers/AppOwnsData/public/js/index.js
+++ b/NodeJS/Embed for your customers/AppOwnsData/public/js/index.js
@@ -73,10 +73,14 @@ $.ajax({
         errorContainer.show();
 
         // Get the error message from err object
-        let errMsg = JSON.parse(err.responseText)['error'];
+        let responseText = JSON.parse(err.responseText)
+        let errMsg = responseText['error'];
 
         // Split the message with \r\n delimiter to get the errors from the error message
         let errorLines = errMsg.split("\r\n");
+
+        // Append error response body to errorLines
+        errorLines.push(`Data: ${responseText['body']}`)
 
         // Create error header
         let errHeader = document.createElement("p");

--- a/NodeJS/Embed for your customers/AppOwnsData/src/embedConfigService.js
+++ b/NodeJS/Embed for your customers/AppOwnsData/src/embedConfigService.js
@@ -31,7 +31,8 @@ async function getEmbedInfo() {
     } catch (err) {
         return {
             'status': err.status,
-            'error': `Error while retrieving report embed details\r\n${err.statusText}\r\nRequestId: \n${err.headers.get('requestid')}`
+            'error': `Error while retrieving report embed details\r\n${err.status} - ${err.statusText}\r\nRequestId: \n${err.headers.get('requestid')}`,
+            'body': await err.text()
         }
     }
 }


### PR DESCRIPTION
When a request fails, the sample node app wasn't showing the request body on the error screen, in turn missing a few important debugging information. 